### PR TITLE
Added glossary terms and tweaked the references slightly.

### DIFF
--- a/docs/glossary.markdown
+++ b/docs/glossary.markdown
@@ -24,21 +24,21 @@ Umbrella term for an application or system with AI components, including dataset
 
 ## Alignment
 
-A general term for how well an [AI System's](#ai-system) outputs (e.g., replies to queries) and behaviors correspond to end-user and service provider objectives, including the quality and utility of results, as well as safety requirements. Quality implies factual correctness and utility implies the results are fit for purpose, e.g., a Q&A system should answer user questions concisely and directly, a Python code-generation system should output valid, bug-free, and secure Python code. [Eleuther AI defines alignment this way](https://www.eleuther.ai/alignment){:target="eleuther"}, &ldquo;Ensuring that an artificial intelligence system behaves in a manner that is consistent with human values and goals.&rdquo; See also the [Alignment Forum](https://www.alignmentforum.org/){:target="alignment-forum"}.
+A general term for how well an [AI System's](#ai-system) outputs (e.g., replies to queries) and behaviors correspond to end-user and service provider objectives, including the quality and utility of results, as well as safety requirements. Quality implies factual correctness and utility implies the results are fit for purpose, e.g., a Q&A system should answer user questions concisely and directly, a Python code-generation system should output valid, bug-free, and secure Python code. [EleutherAI defines alignment this way](https://www.eleuther.ai/alignment){:target="eleuther"}, &ldquo;Ensuring that an artificial intelligence system behaves in a manner that is consistent with human values and goals.&rdquo; See also the [Alignment Forum](https://www.alignmentforum.org/){:target="alignment-forum"}.
 
 ## Annotation
 
-[\[1\]](#mlc) External data that complements a [Dataset](#dataset), such as labels that classify individual items.
+External data that complements a [Dataset](#dataset), such as labels that classify individual items.
 
 ## Benchmark
 
-[\[1\]](#mlc) A methodology or function used for offline evaluation of a model or system for a particular purpose and to interpret the results. It consists of:
+A methodology or function used for offline evaluation of a model or system for a particular purpose and to interpret the results. It consists of:
 * A set of tests with metrics
 * A summarization of the results
 
 ## Dataset
 
-(See also [\[1\]](#mlc)) A collection of data items used for training, evaluation, etc. Usually, a given dataset has a schema (which may be “this is unstructured text”) and some metadata about provenance, licenses for use, transformations and filters applied, etc. 
+A collection of data items used for training, evaluation, etc. Usually, a given dataset has a schema (which may be “this is unstructured text”) and some metadata about provenance, licenses for use, transformations and filters applied, etc. 
 
 ## Explainability
 
@@ -55,6 +55,28 @@ A classifier model or similar tool that can quantify an [AI System's](#ai-system
 ## Hallucination
 
 When a model generates text that seems plausible, but is not factually accurate. Lying is not the right term, because there is no malice intended by the model, which only knows how to generate [Tokens](#token); sequences that are plausible, i.e., probabilistically likely.
+
+## Model
+
+The software package that has been trained on data for purposes like text generation and classification, including APIs required to deploy and query the model.
+
+## OODA Loop
+
+A method of action, where you constantly perform the loop - Observe, Orient, Decide, Act. Originally developed for combat operations, it has been applied in other areas, such as industrial applications, project assessment, etc.
+
+See the [References]({{site.baseurl}}/references#ooda-loop) for more information.
+
+## Prompt Engineering
+
+Techniques for structuring a natural language query to an [AI System](#ai-system) (or [Model](#model) directly) so that you maximize the value of the returned result. The techniques that are most effective will usually depend on components of the system, especially the [Model](#model), and often have to be learned experimentally.
+
+See the [References]({{site.baseurl}}/references#ooda-loop) for more information.
+
+## Retrieval-Augmented Generation
+
+RAG is the first popular design pattern for generative AI-based applications. Based on a user query, datastores are queried for information that is relevant to the query. Relevance is based on a special encoding of the data and a comparison metric that facilitates finding content &ldquo;similar&rdquo; to the query. Some portion of the most relevant retrieved content is added as context with the user query to form the final query sent to the model. RAG improves alignment, especially when data is retrieved that is newer than the data used for the last training or tuning run for the underlying models.
+
+See the [References]({{site.baseurl}}/references#what-is-retrieval-augmented-generation) for more information.
 
 ## Token
 

--- a/docs/references.markdown
+++ b/docs/references.markdown
@@ -18,18 +18,18 @@ has_children: false
 
 ### OODA loop
 
-[link](https://en.wikipedia.org/wiki/OODA_loop){:target="ooda"}
+[Wikipedia page](https://en.wikipedia.org/wiki/OODA_loop){:target="ooda"}
 
-Constantly performing the loop - Observe, Orient, Decide, Act. Originally developed by [United States Air Force Colonel John Boyd](https://en.wikipedia.org/wiki/John_Boyd_(military_strategist)){:target="john-boyd"} for combat operations, it has been applied in other areas, like industrial applications, project assessment, etc.
+The [OODA loop]({{site.baseurl}}/glossary#ooda-loop) involves constantly performing the loop - Observe, Orient, Decide, Act. Originally developed by [United States Air Force Colonel John Boyd](https://en.wikipedia.org/wiki/John_Boyd_(military_strategist)){:target="john-boyd"} for combat operations, it has been applied in other areas, such as industrial applications, project assessment, etc.
 
-### Prompt Engineering
+### Prompt engineering
 
-[link](https://en.wikipedia.org/wiki/Prompt_engineering){:target="wikipedia-prompt"}
+[Wikipedia page](https://en.wikipedia.org/wiki/Prompt_engineering){:target="wikipedia-prompt"}
 
-Wikipedia overview of techniques to manipulate prompts in order to achieve more desirable responses.
+An overview of The [prompt engineering]({{site.baseurl}}/glossary#prompt-engineering) techniques to manipulate prompts in order to achieve more desirable responses.
 
 ### What is retrieval-augmented generation?
 
-[link](https://research.ibm.com/blog/retrieval-augmented-generation-RAG){:target="ibm-rag"}
+[IBM blog post](https://research.ibm.com/blog/retrieval-augmented-generation-RAG){:target="ibm-rag"}
 
-One of many introductions to the popular RAG pattern for improving alignment, especially with data that is newer than the last training or tuning run for the underlying models.
+One of many introductions to the popular [RAG pattern]({{site.baseurl}}/glossary#retrieval-augmented-generation) for improving [alignment]({{site.baseurl}}/glossary#alignment), especially with data that is newer than the last training or tuning run for the underlying models.


### PR DESCRIPTION
Since we have references for RAG, OODA Loop, and Prompt Engineering, I added them as terms. I also added Model for completeness (although it's hard to define succinctly; I assumed the reader already understands the term...)

Also fixed spelling of "EleutherAI" and removed the broken links in the glossary to an MLCommons reference used in the Trust and Safety User Guide.

The "tweaks" to the reference page are mostly links back to the new glossary terms. 